### PR TITLE
fix(server) remove header_filter and body_filter handling for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ RPC Methods:
  - `plugin.StepConsumer()`
  - `plugin.StepMemoryStats()`
 
-To start an event, call `plutin.HandleEvent()` with an instance id and event name.  The return data
+To start an event, call `plugin.HandleEvent()` with an instance id and event name.  The return data
 will include the event ID and either a `"ret"` string or callback request and parameters.  If the
 callback response is a primitive type (number, string, simple dictionary) return it via the
 `plugin.Step()` method, including the event ID.  To return an error, use `plugin.StepError()`.

--- a/instance.go
+++ b/instance.go
@@ -23,8 +23,6 @@ type (
 	certificater interface{ Certificate(*pdk.PDK) }
 	rewriter     interface{ Rewrite(*pdk.PDK) }
 	accesser     interface{ Access(*pdk.PDK) }
-	headerFilter interface{ HeaderFilter(*pdk.PDK) }
-	bodyFilter   interface{ BodyFilter(*pdk.PDK) }
 	prereader    interface{ Preread(*pdk.PDK) }
 	logger       interface{ Log(*pdk.PDK) }
 )
@@ -35,8 +33,6 @@ func getHandlers(config interface{}) map[string]func(kong *pdk.PDK) {
 	if h, ok := config.(certificater); ok { handlers["certificate"]   = h.Certificate  }
 	if h, ok := config.(rewriter)    ; ok { handlers["rewrite"]       = h.Rewrite      }
 	if h, ok := config.(accesser)    ; ok { handlers["access"]        = h.Access       }
-	if h, ok := config.(headerFilter); ok { handlers["header_filter"] = h.HeaderFilter }
-	if h, ok := config.(bodyFilter)  ; ok { handlers["body_filter"]   = h.BodyFilter   }
 	if h, ok := config.(prereader)   ; ok { handlers["preread"]       = h.Preread      }
 	if h, ok := config.(logger)      ; ok { handlers["log"]           = h.Log          }
 


### PR DESCRIPTION
Remove filter phases for now, because those can't be handled efficiently by the Kong side: one cannot open non-blocking sockets in `header_filter` and `body_filter` so we avoid those phases when doing Go plugins to avoid using blocking sockets.

In the future, one option to reenable those phases would be by enabling buffered proxying for Go plugins.