### PR TITLE
feat(cmd) Add CLI command and option to use as a plugin info tool

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,11 +13,38 @@ import (
 )
 
 var kongPrefix = flag.String("kong-prefix", "/usr/local/kong", "Kong prefix path (specified by the `-p` argument commonly used in the `kong` cli)")
+var dump = flag.String("dump-plugin-info", "", "Dump info about `plugin` as a MessagePack object")
+var pluginsDir = flag.String("plugins-directory", "", "Set directory `path` where to search plugins")
+
 var socket string
 
 func init() {
 	flag.Parse()
 	socket = *kongPrefix + "/" + "go_pluginserver.sock"
+
+	if *kongPrefix == "" && *dump == "" {
+		flag.Usage()
+		os.Exit(2)
+	}
+}
+
+func dumpInfo() {
+	s := newServer()
+
+	info := PluginInfo{}
+	err := s.GetPluginInfo(*dump, &info)
+	if err != nil {
+		log.Printf("%s", err)
+	}
+
+	var handle codec.MsgpackHandle
+	handle.ReaderBufferSize = 4096
+	handle.WriterBufferSize = 4096
+	handle.RawToString = true
+	handle.MapType = reflect.TypeOf(map[string]interface{}(nil))
+
+	enc := codec.NewEncoder(os.Stdout, &handle)
+	_ = enc.Encode(info)
 }
 
 func runServer(listener net.Listener) {
@@ -42,7 +69,7 @@ func runServer(listener net.Listener) {
 	}
 }
 
-func main() {
+func startServer() {
 	err := os.Remove(socket)
 	if err != nil && !os.IsNotExist(err) {
 		log.Printf(`removing "%s": %s`, kongPrefix, err)
@@ -58,4 +85,14 @@ func main() {
 	rpc.RegisterName("plugin", newServer())
 
 	runServer(listener)
+}
+
+func main() {
+	if *dump != "" {
+		dumpInfo()
+	}
+
+	if socket != "" {
+		startServer()
+	}
 }

--- a/pluginserver.go
+++ b/pluginserver.go
@@ -26,11 +26,21 @@ type PluginServer struct {
 
 // Create a new server context.
 func newServer() *PluginServer {
-	return &PluginServer{
+	s := PluginServer{
 		plugins:   map[string]*pluginData{},
 		instances: map[int]*instanceData{},
 		events:    map[int]*eventData{},
 	}
+
+	if *pluginsDir == "" {
+		if dir, err := os.Getwd(); err == nil {
+			s.pluginsDir = dir
+		}
+	} else {
+		s.pluginsDir = *pluginsDir
+	}
+
+	return &s
 }
 
 // SetPluginDir tells the server where to find the plugins.
@@ -47,7 +57,7 @@ func (s *PluginServer) SetPluginDir(dir string, reply *string) error {
 // --- status --- //
 
 type ServerStatusData struct {
-	Pid int
+	Pid     int
 	Plugins map[string]PluginStatusData
 }
 
@@ -56,7 +66,7 @@ func (s *PluginServer) GetStatus(n int, reply *ServerStatusData) error {
 	defer s.lock.Unlock()
 
 	*reply = ServerStatusData{
-		Pid: os.Getpid(),
+		Pid:     os.Getpid(),
 		Plugins: make(map[string]PluginStatusData),
 	}
 
@@ -213,8 +223,8 @@ func getSchemaDict(t reflect.Type) schemaDict {
 // Information obtained from a plugin's compiled code.
 type PluginInfo struct {
 	Name     string     // plugin name
-	ModTime  time.Time  // plugin file modification time
-	LoadTime time.Time  // plugin load time
+	ModTime  time.Time  `codec:",omitempty"` // plugin file modification time
+	LoadTime time.Time  `codec:",omitempty"` // plugin load time
 	Phases   []string   // events it can handle
 	Version  string     // version number
 	Priority int        // priority info


### PR DESCRIPTION
- -plugins-directory <dir>  option sets the starting plugin directory
- -dump-plugin-info <name>  command returns the same data as the `plugin.GetPluginInfo()`
   method.  The result is dumped as a MessagePack object on stdout.

This way, the Kong process can query Go plugins during init phases without spawning the pluginserver, just use `pluginserver -dir <goplugindsdir> -dump <pluginname>`.  The actual management of the pluginserver can be handled later by a worker process.