### PR TITLE
feat(*) accept kong-prefix instead of socket name

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,15 +12,12 @@ import (
 	"reflect"
 )
 
-var socket = flag.String("socket", "", "Socket to listen into")
+var kongPrefix = flag.String("kong-prefix", "/usr/local/kong", "Kong prefix path (specified by the `-p` argument commonly used in the `kong` cli)")
+var socket string
 
 func init() {
 	flag.Parse()
-
-	if *socket == "" {
-		flag.Usage()
-		os.Exit(2)
-	}
+	socket = *kongPrefix + "/" + "go_pluginserver.sock"
 }
 
 func runServer(listener net.Listener) {
@@ -46,13 +43,13 @@ func runServer(listener net.Listener) {
 }
 
 func main() {
-	err := os.Remove(*socket)
+	err := os.Remove(socket)
 	if err != nil && !os.IsNotExist(err) {
-		log.Printf(`removing "%s": %s`, socket, err)
+		log.Printf(`removing "%s": %s`, kongPrefix, err)
 		return
 	}
 
-	listener, err := net.Listen("unix", *socket)
+	listener, err := net.Listen("unix", socket)
 	if err != nil {
 		log.Printf(`listen("%s"): %s`, socket, err)
 		return

--- a/test.sh
+++ b/test.sh
@@ -12,14 +12,14 @@ rq --help >/dev/null
 
 echo "pwd: $PWD"
 
-SOCKET='sock'
+SOCKET='go_pluginserver.sock'
 
 if pgrep go-pluginserver -l; then
 	PREVIOUS_SERVER="yes"
 else
 	echo "starting server..."
 	[ -S "$SOCKET" ] && rm "$SOCKET"
-	./go-pluginserver -socket "$SOCKET" &
+	./go-pluginserver -kong-prefix . &
 	pgrep go-pluginserver -l
 	sleep 0.1s
 fi


### PR DESCRIPTION
This commit replaces the `-socket` flag with `-kong-prefix` and
hardcodes the socket name, which is expected by Kong to be in the Kong
prefix.