### PR TITLE
handle closed channel to allow plugins to terminate processing

### DIFF
--- a/event.go
+++ b/event.go
@@ -59,12 +59,16 @@ func (s *PluginServer) HandleEvent(in StartEventData, out *StepData) error {
 	go func() {
 		_ = <-ipc
 		h(event.pdk)
-		ipc <- "ret"
+
+		func() {
+			defer func() { recover() }()
+			ipc <- "ret"
+		}()
 
 		s.lock.Lock()
+		defer s.lock.Unlock()
 		event.instance.lastEvent = time.Now()
 		delete(s.events, event.id)
-		s.lock.Unlock()
 	}()
 
 	ipc <- "run" // kickstart the handler


### PR DESCRIPTION
When the Go plugin asks Kong to exit, the callback cycle is broken.  To ensure we don't send the `"ret"` end signal, the go-pdk function closes the channel.  Unfortunately, there's no way to check if it's closed before trying to write, so we have to handle the runtime panic.