### PR TITLE
Key/Value types for map are incorrectly mapped

### DIFF
--- a/pluginserver.go
+++ b/pluginserver.go
@@ -193,7 +193,7 @@ func getSchemaDict(t reflect.Type) schemaDict {
 		return schemaDict{
 			"type":   "map",
 			"keys":   kType,
-                        "values": vType,
+			"values": vType,
 		}
 
 	case reflect.Struct:

--- a/pluginserver.go
+++ b/pluginserver.go
@@ -192,8 +192,8 @@ func getSchemaDict(t reflect.Type) schemaDict {
 		}
 		return schemaDict{
 			"type":   "map",
-			"keys":   schemaDict{"type": kType},
-			"values": schemaDict{"type": vType},
+			"keys":   kType,
+                        "values": vType,
 		}
 
 	case reflect.Struct:


### PR DESCRIPTION
Hi,

The plugin server seems to incorrectly map the types for key and value for maps in configuration. The type of the key and value has an extra `{ "type": <type> }` that makes the generate schema to be invalid.

For example:

```go
type Service struct {
  Something bool
}

type Config struct {
  Services map[string]Service
}
```

The generated scheme (in json) using the current code is (this makes kong to fail at startup):

```json
{
    "fields": [
        {
            "services": {
                "keys": {
                    "type": {
                        "type": "string"
                    }
                },
                "type": "map",
                "values": {
                    "type": {
                        "fields": [
                            {
                                "something": {
                                    "type": "boolean"
                                }
                            }
                        ],
                        "type": "record"
                    }
                }
            }
        }
    ],
    "type": "record"
}
```

With the patch in this PR, the generated scheme is now:

```json
{
    "fields": [
        {
            "services": {
                "keys": {
                    "type": "string"
                },
                "type": "map",
                "values": {
                    "fields": [
                        {
                            "something": {
                                "type": "boolean"
                            }
                        }
                    ],
                    "type": "record"
                }
            }
        }
    ],
    "type": "record"
}
```

This PR tries to fix this behaviour in the schema mapping.