### PR TITLE
tests(*) new plugin name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_script:
   - tar zxvpf rq.tar.gz
   - go get -v -u golang.org/x/lint/golint
   - ( cd ~/gopath/src; mkdir -p github.com/Kong; cd github.com/Kong; git clone https://github.com/kong/go-pdk && cd go-pdk && go install )
-  - ( cd ~/gopath/src/github.com/Kong; git clone https://github.com/kong/go-plugins && cd go-plugins && make && cp *.so ../go-pluginserver )
+  - ( cd ~/gopath/src/github.com/Kong; git clone https://github.com/kong/go-plugins && cd go-plugins && git checkout v0.5.0 && make && cp *.so ../go-pluginserver )
 
 script:
   - golint ./...

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/Kong/go-pluginserver
 go 1.13
 
 require (
-	github.com/Kong/go-pdk v0.6.0
+	github.com/Kong/go-pdk v0.6.1
 	github.com/ugorji/go/codec v1.2.1
 )

--- a/test.sh
+++ b/test.sh
@@ -71,15 +71,15 @@ msg '[0, 19, "plugin.GetStatus", []]'
 assert_noerr
 assert_fld_match 'Plugins' '{}'
 
-msg '[0, 19, "plugin.GetPluginInfo", ["go-hello"]]'
+msg '[0, 19, "plugin.GetPluginInfo", ["go-hello-lm"]]'
 assert_noerr
 
-msg '[0, 19, "plugin.StartInstance", [{"Name":"go-hello", "Config":"{\"message\":\"howdy\"}"}]]'
+msg '[0, 19, "plugin.StartInstance", [{"Name":"go-hello-lm", "Config":"{\"message\":\"howdy\"}"}]]'
 assert_noerr
 helloId=$(query_result '."Id"')
 echo "helloId: $helloId"
 
-msg '[0, 19, "plugin.StartInstance", [{"Name":"go-log", "Config":"{\"reopen\":false, \"path\":\"/some/where/else/\"}"}]]'
+msg '[0, 19, "plugin.StartInstance", [{"Name":"go-log-lm", "Config":"{\"reopen\":false, \"path\":\"/some/where/else/\"}"}]]'
 assert_noerr
 logId=$(query_result '."Id"')
 echo "logId: $logId"
@@ -143,8 +143,8 @@ assert_noerr
 
 msg '[0, 19, "plugin.GetStatus", []]'
 assert_noerr
-assert_fld_match 'Plugins["go-hello"]' '"Name": "go-hello"'
-assert_fld_match 'Plugins["go-log"]' '"Name": "go-log"'
+assert_fld_match 'Plugins["go-hello-lm"]' '"Name": "go-hello-lm"'
+assert_fld_match 'Plugins["go-log-lm"]' '"Name": "go-log-lm"'
 
 
 if [ ! -v PREVIOUS_SERVER ]; then


### PR DESCRIPTION
Since the embedded plugin server was added, the sample plugins were adapted to the new paradigm. The old "loadable module" samples were renamed to include a -lm suffix. This PR fixes the names in tests and pins the go-plugins version to v0.5.0.